### PR TITLE
fix(lists): expañolizar los comandos

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -113,7 +113,7 @@ def uwuspeech(update: Update, context: CallbackContext) -> None:
             text=message)
 
 
-def repeat(update: Update, context: CallbackContext) -> None:
+def repetir(update: Update, context: CallbackContext) -> None:
     """
     Repeats a given message
     """
@@ -128,13 +128,13 @@ def repeat(update: Update, context: CallbackContext) -> None:
             text=arg)
 
 
-def startlist(update: Update, context: CallbackContext) -> None:
+def lista(update: Update, context: CallbackContext) -> None:
     """
     Starts an editable list
     """
     log_command(update)
     arg = get_arg(update)
-    message = f"#list {arg}:"
+    message = f"#LISTA {arg}:"
 
     try_msg(context.bot,
             chat_id=update.message.chat_id,
@@ -142,7 +142,7 @@ def startlist(update: Update, context: CallbackContext) -> None:
             text=message)
 
 
-def add(update: Update, context: CallbackContext) -> None:
+def agregar(update: Update, context: CallbackContext) -> None:
     """
     Adds an item to a list
     """
@@ -173,7 +173,7 @@ def add(update: Update, context: CallbackContext) -> None:
     )
 
 
-def remove(update: Update, context: CallbackContext) -> None:
+def quitar(update: Update, context: CallbackContext) -> None:
     """
     Removes an item from a list
     """

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ from telegram.ext import CommandHandler, Filters
 import data
 from bot import updater, dp
 from commands import start, tup, desiglar, siglar, slashear, uwuspeech, \
-                        repeat, startlist, add, remove, get_log
+                        repetir, lista, agregar, quitar, get_log
 from config.auth import admin_ids
 
 
@@ -20,10 +20,10 @@ def main():
     dp.add_handler(CommandHandler('uwuizar', uwuspeech))
     dp.add_handler(CommandHandler('uwu', uwuspeech))
 
-    dp.add_handler(CommandHandler('repeat', repeat))
-    dp.add_handler(CommandHandler('startlist', startlist))
-    dp.add_handler(CommandHandler('add', add))
-    dp.add_handler(CommandHandler('remove', remove))
+    dp.add_handler(CommandHandler('repetir', repetir))
+    dp.add_handler(CommandHandler('lista', lista))
+    dp.add_handler(CommandHandler('agregar', agregar))
+    dp.add_handler(CommandHandler('quitar', quitar))
 
     # Admin commands
     dp.add_handler(CommandHandler('get_log', get_log,


### PR DESCRIPTION
Nuevos nombres:

## /repetir
Repeats the message content, or the content of the message being replied to

## /lista
Starts a bot curated list, with a hashtag for easy searching

## /agregar
Adds an item to a bot list (only works as a reply)

## /quitar
Removes an item from a bot list (only works as a reply)
