### PR TITLE
Feature/glossary

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -1,13 +1,14 @@
 import os
 from datetime import datetime
 
-from telegram import Update
+from telegram import Update, ParseMode, constants
 from telegram.ext import CallbackContext
+from telegram.utils.helpers import escape_markdown
 
 import data
 from config.logger import log_command
 from utils import generate_acronym, get_arg, reverse_acronym, try_msg, \
-    try_edit, guard_editable_bot_message
+    try_edit, guard_editable_bot_message, member_check
 
 
 def start(update: Update, context: CallbackContext) -> None:
@@ -129,6 +130,67 @@ def siglar(update: Update, context: CallbackContext) -> None:
             chat_id=update.message.chat_id,
             parse_mode="HTML",
             text=message)
+
+
+def glosario(update: Update, context: CallbackContext) -> None:
+    """Sends a list of acronyms and meanings to the private chat
+    of the user that called the command."""
+
+    log_command(update)
+
+    if not member_check(update, context):
+        return
+
+    arg = get_arg(update)
+
+    if arg:
+        if len(arg) > 1:
+            try_msg(context.bot,
+                    chat_id=update.message.chat_id,
+                    parse_mode="HTML",
+                    text="Este comando sólo puede invocarse "
+                         "con 1 (un) caracter o ninguno.")
+            return
+        acronyms = data.Acronyms.list_by_letter(arg.lower())
+        if not acronyms:
+            try_msg(context.bot,
+                    chat_id=update.message.chat_id,
+                    parse_mode="HTML",
+                    text=f"No encontré siglas que empiecen con {arg} :^(")
+            return
+    else:
+        acronyms = data.Acronyms.list_all()
+
+    acronyms.sort(key=lambda x: x[0])
+
+    if update.message.from_user.id != update.message.chat_id:
+        try_msg(context.bot,
+                chat_id=update.message.chat_id,
+                parse_mode="HTML",
+                text=f"Enviaré la lista de siglas a tu chat privado ;^)")
+
+    separator = f"\n➖➖➖➖➖➖➖"
+    msg = separator
+
+    for idx, acro in enumerate(acronyms):
+        definition = f"\n{acro[0]}\n{acro[1]}"
+
+        if len(msg + definition + separator) > constants.MAX_MESSAGE_LENGTH:
+            try_msg(context.bot,
+                    chat_id=update.message.from_user.id,
+                    parse_mode=ParseMode.MARKDOWN_V2,
+                    text=escape_markdown(msg, version=2),
+                    disable_web_page_preview=True)
+            msg = separator
+
+        msg += definition + separator
+
+        if idx == len(acronyms) - 1:
+            try_msg(context.bot,
+                    chat_id=update.message.from_user.id,
+                    parse_mode=ParseMode.MARKDOWN_V2,
+                    text=escape_markdown(msg, version=2),
+                    disable_web_page_preview=True)
 
 
 # --- List Commands ---

--- a/commands.py
+++ b/commands.py
@@ -34,49 +34,6 @@ def tup(update: Update, context: CallbackContext) -> None:
             text=message)
 
 
-def desiglar(update: Update, context: CallbackContext) -> None:
-    """
-    Turns an acronym into its corresponding phrase
-    """
-    log_command(update)
-    arg = get_arg(update)
-    if update.message.reply_to_message and not arg:
-        arg = update.message.reply_to_message.text
-
-    message = data.Acronyms.get(arg.lower())
-    if message is None:
-        message = reverse_acronym(arg.lower())
-        message += "\n<i>Para hacer una sigla real:</i> /siglar"
-
-    try_msg(context.bot,
-            chat_id=update.message.chat_id,
-            parse_mode="HTML",
-            text=message)
-
-
-def siglar(update: Update, context: CallbackContext) -> None:
-    """
-    Saves a phrase as an acronym
-    """
-    log_command(update)
-    arg = get_arg(update)
-    if update.message.reply_to_message and not arg:
-        arg = update.message.reply_to_message.text
-
-    acronym = generate_acronym(arg)
-
-    old_acronym = data.Acronyms.set(acronym, arg)
-
-    message = acronym
-    if old_acronym is not None:
-        message += f"\n<i>(Reemplaza '{old_acronym}')</i>"
-
-    try_msg(context.bot,
-            chat_id=update.message.chat_id,
-            parse_mode="HTML",
-            text=message)
-
-
 def slashear(update, context):
     log_command(update)
     if update.message.reply_to_message:
@@ -127,6 +84,51 @@ def repetir(update: Update, context: CallbackContext) -> None:
             chat_id=update.message.chat_id,
             parse_mode="HTML",
             text=arg)
+
+# --- Acronym Commands ---
+
+
+def desiglar(update: Update, context: CallbackContext) -> None:
+    """
+    Turns an acronym into its corresponding phrase
+    """
+    log_command(update)
+    arg = get_arg(update)
+    if update.message.reply_to_message and not arg:
+        arg = update.message.reply_to_message.text
+
+    message = data.Acronyms.get(arg.lower())
+    if message is None:
+        message = reverse_acronym(arg.lower())
+        message += "\n<i>Para hacer una sigla real:</i> /siglar"
+
+    try_msg(context.bot,
+            chat_id=update.message.chat_id,
+            parse_mode="HTML",
+            text=message)
+
+
+def siglar(update: Update, context: CallbackContext) -> None:
+    """
+    Saves a phrase as an acronym
+    """
+    log_command(update)
+    arg = get_arg(update)
+    if update.message.reply_to_message and not arg:
+        arg = update.message.reply_to_message.text
+
+    acronym = generate_acronym(arg)
+
+    old_acronym = data.Acronyms.set(acronym, arg)
+
+    message = acronym
+    if old_acronym is not None:
+        message += f"\n<i>(Reemplaza '{old_acronym}')</i>"
+
+    try_msg(context.bot,
+            chat_id=update.message.chat_id,
+            parse_mode="HTML",
+            text=message)
 
 
 # --- List Commands ---

--- a/config/auth-sample.py
+++ b/config/auth-sample.py
@@ -2,3 +2,4 @@
 
 token = "BotTokenAsString"
 admin_ids = [100000001, 100000002]
+group_id = 0

--- a/data.py
+++ b/data.py
@@ -1,5 +1,4 @@
 import sqlite3
-from typing import Optional
 
 import config.db
 from config.logger import logger
@@ -55,3 +54,20 @@ class Acronyms:
         if row is None:
             return None
         return row[0]
+
+    @staticmethod
+    def list_all() -> list[tuple[str, str]]:
+        """Lists all acronym definitions."""
+        cur = connect().cursor()
+        rows = cur.execute('SELECT * FROM Acronyms').fetchall()
+        return rows
+
+    @staticmethod
+    def list_by_letter(let: str) -> list[tuple[str, str]]:
+        """Lists all acronyms starting with a certain letter, and
+         their definitions."""
+        cur = connect().cursor()
+        rows = cur.execute(
+            f"SELECT * FROM Acronyms WHERE (acronym LIKE '{let}%')"
+        ).fetchall()
+        return rows

--- a/main.py
+++ b/main.py
@@ -3,8 +3,8 @@ from telegram.ext import CommandHandler, Filters
 import data
 from bot import updater, dp
 from commands import start, tup, desiglar, siglar, slashear, uwuspeech, \
-                        repetir, lista, agregar, quitar, editar, deslistar, \
-                        get_log, contador, sumar, restar
+    repetir, lista, agregar, quitar, editar, deslistar, \
+    get_log, contador, sumar, restar, glosario
 from config.auth import admin_ids
 
 
@@ -12,16 +12,19 @@ def main():
     data.init()
 
     dp.add_handler(CommandHandler('start', start))
-    dp.add_handler(CommandHandler('tup', tup))
+
+    # ==== SIGLAS ====
     dp.add_handler(CommandHandler('desiglar', desiglar))
     dp.add_handler(CommandHandler('siglar', siglar))
-    dp.add_handler(CommandHandler('slashear', slashear))
+    dp.add_handler(CommandHandler('glosario', glosario))
+
+    # ==== UWU ====
     dp.add_handler(CommandHandler('uwuspeech', uwuspeech))
     dp.add_handler(CommandHandler('uwuspeak', uwuspeech))
     dp.add_handler(CommandHandler('uwuizar', uwuspeech))
     dp.add_handler(CommandHandler('uwu', uwuspeech))
 
-    dp.add_handler(CommandHandler('repetir', repetir))
+    # ==== LISTA ====
     dp.add_handler(CommandHandler('lista', lista))
     dp.add_handler(CommandHandler('agregar', agregar))
     dp.add_handler(CommandHandler('quitar', quitar))
@@ -29,11 +32,17 @@ def main():
     dp.add_handler(CommandHandler('deslistar', deslistar))
     dp.add_handler(CommandHandler('cerrar', deslistar))
 
+    # ==== CONTADOR ====
     dp.add_handler(CommandHandler('contador', contador))
     dp.add_handler(CommandHandler('sumar', sumar))
     dp.add_handler(CommandHandler('incrementar', sumar))
     dp.add_handler(CommandHandler('restar', restar))
     dp.add_handler(CommandHandler('decrementar', restar))
+
+    # ==== MISC ====
+    dp.add_handler(CommandHandler('tup', tup))
+    dp.add_handler(CommandHandler('slashear', slashear))
+    dp.add_handler(CommandHandler('repetir', repetir))
 
     # Admin commands
     dp.add_handler(CommandHandler('get_log', get_log,

--- a/utils.py
+++ b/utils.py
@@ -1,9 +1,12 @@
 import random
 import re
-from config.logger import logger
 from string import ascii_lowercase
+
 from telegram import Update, Bot, TelegramError, constants as tg_constants
 from telegram.ext import CallbackContext
+
+from config.auth import group_id
+from config.logger import logger
 
 word_file = "static/words.txt"
 WORDS = open(word_file).read().splitlines()
@@ -208,3 +211,19 @@ def guard_editable_bot_message(update: Update,
         return True
 
     return False
+
+
+def member_check(update: Update, context: CallbackContext) -> bool:
+    """If the update was not sent by a member of the group configured in
+    auth.py, sends a "forbidden" message.
+    Returns whether the user is member of the group."""
+    chat_member = context.bot.getChatMember(group_id,
+                                            update.message.from_user.id)
+
+    if chat_member.status not in ["administrator", "creator", "member"]:
+        try_msg(context.bot,
+                chat_id=update.message.chat_id,
+                parse_mode="HTML",
+                text="<b>403 FORBIDDEN</b>")
+        return False
+    return True


### PR DESCRIPTION
Crea el comando `/glosario`, un comando gracioso que envía **TODAS LAS SIGLAS** al chat privado de quien lo invoca, sólo si pertenece a La Organización™. También se puede invocar con un caracter para recibir sólo las siglas que empiezan con ese caracter.

Ejemplo:
`/glosario` envía todas las siglas al chat privado.
`/glosario H` envía todas las siglas que empiezan con H al chat privado.
`/glosario Jjjjajajkshs` envía un mensaje de error, ya que sólo acepta una letra (o ninguna) como argumento.
`/glosario }` envía un mensaje de error, ya que a la fecha no hay siglas que empiecen con }.
Cualquiera de los comandos anteriores es respondido con un **403 FORBIDDEN** si la persona no pertenece a La Organización™.

Requiere configurar una variable llamada `group_id` en `auth.py` antes de echar a correr el bot.

Lo probé en mi propio bot de prueba :^)