### PR TITLE
Comando /noticia (/quepaso) para resumir titulares

### DIFF
--- a/commands/summary.py
+++ b/commands/summary.py
@@ -1,11 +1,11 @@
-import requests
-import data
 import json
+from newspaper.google_news import GoogleNewsSource
 
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, CallbackQuery
 from telegram.ext import CallbackContext
 from openai import OpenAI
 
+import data
 from commands.decorators import group_exclusive, member_exclusive
 from config.logger import log_command
 from utils import (
@@ -306,4 +306,61 @@ def button(update: Update, context: CallbackContext) -> None:
             )
             _do_resumir(query, context)
         elif query_data[0] == "cancel_summary":
-            query.edit_message_text(text=f"{query.message.text}\n\nResumen cancelado.")
+            query.edit_message_text(
+                text=f"{query.message.text}\n\nResumen cancelado.")
+
+
+@member_exclusive
+def noticia(update: Update, context: CallbackContext) -> None:
+    """
+    Summarizes a news article.
+    """
+    arg = get_arg(update)
+    if not arg:
+        return
+
+    source = GoogleNewsSource(
+        country="CL",
+        language="es",
+        max_results=10,
+    )
+    source.build(top_news=False, keyword=arg)
+
+    titles = [article.title for article in source.articles]
+
+    PROMPT_NEWS_HEADLINES = {
+        "role": "system",
+        "content": "Eres un bot para resumir titulares de noticias. "
+        + "Te daré varios titulares recientes y debes intentar inferir qué está pasando, de forma concisa, en no más de 1000 caracteres."
+        + "No incluyas nada más que el resumen en tu mensaje. No menciones las fuentes."
+    }
+    client = OpenAI(api_key=openai_key)
+    chat_completion = client.chat.completions.create(
+        model=GPT_MODEL,
+        messages=[
+            PROMPT_NEWS_HEADLINES,
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "\n".join(titles)
+                    }
+                ],
+            },
+        ],
+    )
+    result = chat_completion.choices[0].message.content
+
+    url = source.url + "search?q=" + "%20".join(arg.split(" ")) + source.gnews._ceid()
+    message = result + "\n\n" + f"⛲️ Fuente: <a href='{url}'>Google News</a>"
+
+    try_msg(
+        context.bot,
+        chat_id=update.message.chat_id,
+        parse_mode="HTML",
+        text=message,
+        reply_to_message_id=update.message.message_id,
+    )
+    return
+

--- a/commands/summary.py
+++ b/commands/summary.py
@@ -353,7 +353,7 @@ def noticia(update: Update, context: CallbackContext) -> None:
     result = chat_completion.choices[0].message.content
 
     url = source.url + "search?q=" + "%20".join(arg.split(" ")) + source.gnews._ceid()
-    message = result + "\n\n" + f"⛲️ Fuente: <a href='{url}'>Google News</a>"
+    message = result + "\n\n" + f"⛲️ <a href='{url}'>Google News</a>"
 
     try_msg(
         context.bot,

--- a/main.py
+++ b/main.py
@@ -92,7 +92,7 @@ def main():
 
     # Summary
     add_command('resumir', resumir)
-    add_command(['noticia', 'quepaso'], noticia)
+    add_command(['noticia', 'noticias', 'quepaso'], noticia)
 
     dp.add_handler(CallbackQueryHandler(button))
 

--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from commands.admin import get_log, prohibir
 from commands.counter import contador, sumar, restar
 from commands.list import lista, agregar, quitar, editar, deslistar
 from commands.response import start, tup, gracias, weekly_poll, reply_hello
-from commands.summary import resumir, button
+from commands.summary import resumir, noticia, button
 from commands.text import slashear, uwuspeech, repetir
 from commands.gpt import reply_gpt, reply_fill, desigliar
 
@@ -92,6 +92,7 @@ def main():
 
     # Summary
     add_command('resumir', resumir)
+    add_command(['noticia', 'quepaso'], noticia)
 
     dp.add_handler(CallbackQueryHandler(button))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ httpcore==1.0.5
 httpx==0.27.0
 huggingface-hub==0.23.0
 idna==3.7
+newspaper4k==0.9.3
 openai==1.35.1
 packaging==24.0
 pydantic==2.7.1


### PR DESCRIPTION
# QUÉ PASÓ
Agrega el comando `/noticia`, con los alias equivalentes `/noticias` y `/quepaso`, que resumen los titulares recientes sobre un tema.
## Uso
```
/quepaso metro bio bio
```
Respuesta:
> La estación Bío Bío de la Línea 6 del Metro de Santiago sufrió un extenso cierre debido a problemas de anegación en las vías. A pesar de los esfuerzos de drenaje, la acumulación de agua persistió, ocasionando su clausura durante varios días. Esta situación también afectó el servicio en la Línea 5, con fallos adicionales en los trenes. Recientemente, la estación Bío Bío ha sido reabierta tras resolver parcialmente los problemas de anegación que interrumpieron su funcionamiento.
>
>⛲️ Google News (https://news.google.com/search?q=metro%20bio%20bio&hl=es&gl=CL&ceid=CL:es)

## Cómo
Utiliza la librería [newspaper4k](https://github.com/AndyTheFactory/newspaper4k) para obtener los titulares de Google News. Los primeros 10 titulares se envían a GPT para obtener el resumen.

## Requisitos
Requiere hacer un `pip install -r requirements.txt`

## Ideas futuras
Que entre a los primeros 1-3 links y obtenga la noticia completa, para obtener un resumen más detallado, que podría pedirse con otro comando o con un reply.